### PR TITLE
Ensure setTimeout milliseconds is below the max value

### DIFF
--- a/session_security/static/session_security/script.js
+++ b/session_security/static/session_security/script.js
@@ -136,7 +136,10 @@ yourlabs.SessionSecurity.prototype = {
             nextPing = this.warnAfter - idleFor;
         }
 
-        this.timeout = setTimeout($.proxy(this.ping, this), nextPing * 1000);
+        // setTimeout expects the timeout value not to exceed
+        // a 32-bit unsigned int, so cap the value
+        var milliseconds = Math.min(nextPing * 1000, 2147483647)
+        this.timeout = setTimeout($.proxy(this.ping, this), milliseconds);
     },
 
     // onbeforeunload handler.


### PR DESCRIPTION
The Javascript setTimeout() function will execute immediately if the millisecond value is greater than an unsigned 32-bit int. This means if a developer sets WARN_AFTER and EXPIRE_AFTER to a high enough value, then the ping/pong will rapid-fire non-stop.   You can see the problem by setting WARN_AFTER and EXPIRE_AFTER to 2147484 or higher.  I discovered this when setting the value very high in a dev environment to effectively disable session expiration.  This pull request ensures this cap is not exceeded.